### PR TITLE
Fix manual update button

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -14,7 +14,7 @@
         * [Apache without SSL](latest/panel/webservers/apache.md)
         
     * `Updating`
-        * [Manual Update](latest/panel/update/manual.md)
+        * [Manual Update](latest/panel/updating/manual.md)
 
 * **Daemon (v1.x)**
     * [Installation](latest/daemon/install.md)


### PR DESCRIPTION
I just fixed the manual update button as it was using the wrong url and should have been `latest/panel/updating/manual.md` but was `latest/panel/update/manual.md`